### PR TITLE
another design

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ You must install __libsndfile__ to build the binding. You can download it direct
 or with your favorite package management tool.
 
 Then clone the __rust-sndfile__ repository and build it with make.
+
+# Fork Diff
+
+SndFile no longer implement Clone.
+
+SndFile impl Send.
+
+SndFile impl Drop and close method is private

--- a/src/sndfile.rs
+++ b/src/sndfile.rs
@@ -62,6 +62,7 @@ extern crate libc;
 use std::path::Path;
 use std::ptr;
 use std::ffi::{CStr, CString};
+use std::ops::Drop;
 
 #[doc(hidden)]
 mod libsndfile {
@@ -317,12 +318,9 @@ pub struct SndFile {
     info : SndInfo
 }
 
-impl Clone for SndFile {
-    fn clone(&self) -> SndFile {
-        SndFile {
-            handle : self.handle,
-            info : self.info.clone()
-        }
+impl Drop for SndFile {
+    fn drop(&mut self) {
+        self.close().unwrap();
     }
 }
 
@@ -474,7 +472,7 @@ impl SndFile {
      *
      * Return NoError if destruction success, an other error code otherwise.
      */
-    pub fn close(&self) -> SndFileResult<()> {
+    fn close(&self) -> SndFileResult<()> {
         let error_code = unsafe { ffi::sf_close(self.handle) };
         SndFileError::code_to_result(error_code, ())
     }

--- a/src/sndfile.rs
+++ b/src/sndfile.rs
@@ -318,6 +318,8 @@ pub struct SndFile {
     info : SndInfo
 }
 
+unsafe impl Send for SndFile {}
+
 impl Drop for SndFile {
     fn drop(&mut self) {
         self.close().unwrap();


### PR DESCRIPTION
here is another design for the sndfile crate.

I'm making this pull request in order to inform about this and have feedback about this.
feel free to close it.

I wanted to have SnfFile implement Send.
Thus I delete the implementation of Clone as it shared the same pointer handle.
(also I think sharing this pointer is weird and doesn't correspond to the way Rust want to manage memory)

Finally I implemented Drop that just call close and unwrap.

the implementation of Send for C binding have explanation here:
https://users.rust-lang.org/t/mut-const-and-proper-send-sync-on-stable-rust/4007/4

I didn't dive into libsndfile C code that much to see if it can safely be moved between thread. But I assumed it's true and I'll make test in the future
